### PR TITLE
add statuses into state

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "immstruct": "^1.4.0",
     "immutable": "^3.7.1",
     "levelup": "^0.19.0",
+    "lodash": "^3.9.3",
     "memdown": "^1.0.0",
     "when": "^3.7.2"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,13 @@ const workspaceStore = require('./stores/workspace');
 const fileActions = require('./actions/file');
 const currentActions = require('./actions/current');
 const directoryActions = require('./actions/directory');
+const statuses = require('./statuses');
 
 function frylord(app, opts, cb){
 
   const namespace = opts.namespace || 'workspace';
+
+  workspaceStore.statuses = statuses;
 
   app.expose(namespace, workspaceStore);
   app.expose('file', fileActions);


### PR DESCRIPTION
#### What's this PR do?

Adds a status enumeration and status + message to the stores state for tracking async behavior in the views.
#### Where should the reviewer start?

The store contains most of the logic for when events are triggered. Default statuses and message are in the statuses.js file.
#### How should this be manually tested?

Not sure.
#### Any background context you want to provide?

These are needed since we don't have callbacks.
